### PR TITLE
Added Techcrunch selector (experimental)

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -29,6 +29,12 @@
             "re_url_match": "bloomberg.com$",
             "title_selector": "h1.lede-text-only__hed > span",
             "body_selector": "div.body-copy > p"
+        },
+        {
+            "name": "techcrunch",
+            "re_url_match": "techcrunch.com$",
+            "title_selector": "h1.alpha.tweet-title",
+            "body_selector": "div.article-entry"
         }
     ]
 }


### PR DESCRIPTION
Works okay for articles without bylines (
https://techcrunch.com/2017/10/19/two-google-alums-just-raised-60m-to-rethink-documents/
)

A little bit uglier with a byline (
https://techcrunch.com/2017/10/22/defensible-strategies-for-food-tech-entrepreneurs-facing-the-amazon-juggernaut/
)

Would be ideal to exclude `div.byline` in the body selector but the current implementation doesn't seem to be able to do that yet 