### PR TITLE
Support for in-text hyperlinks to Markdown

### DIFF
--- a/modules/article.py
+++ b/modules/article.py
@@ -4,11 +4,11 @@ from bs4 import BeautifulSoup as bs
 class article:
 
     def __init__(self, url, site):
-        header = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
+        headers = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
         AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 \
         Safari/537.36"}
 
-        r = requests.get(url, header=header)
+        r = requests.get(url, headers=headers)
 
         if (r.status_code != 200): # if GET request fails
             print("Error: " + str(r.status_code))
@@ -23,6 +23,13 @@ class article:
 
     def get_body(self, site):
         body = ""
+
+        # hyperlinks to markdown
         for paragraph in self.soup.select(site["body_selector"]):
+            if paragraph.a:
+                gen = (a for a in paragraph.select("a") if a.string is not None)
+                for a in gen:
+                    a.string = "[" + a.string + "](" + a.get("href") + ")"
+
             body += "> " + paragraph.get_text() + "\n\n"
         return body


### PR DESCRIPTION
Hyperlinks will now be posted in Markdown-compatible formatting. Also
fixed a typo in the previous commit with the keyword argument "header"
in request()