### PR TITLE
Added feature to extract authors' names from articles

### DIFF
--- a/modules/mercury.py
+++ b/modules/mercury.py
@@ -16,6 +16,7 @@ class mercury:
         j = json.loads(r.text)
 
         self.title = j["title"]
+        self.author = j["author"]
         self.content = j["content"]
         self.date_published = j["date_published"]
         self.lead_image_url = j["lead_image_url"]

--- a/retrivr.py
+++ b/retrivr.py
@@ -50,7 +50,12 @@ for submission in rsg.new(limit=10):
             with open("footer_meta.md", "r") as f:
                 post_footer += f.read()
 
-            post = "> #" + a.title + "\n\n" + a.body + post_footer
+            post_author = ""
+
+            if a.author is not None:
+                post_author = "> #####By " + a.author + "\n\n"
+
+            post = "> #" + a.title + "\n\n" + post_author + a.body + post_footer
 
             # post my comment subject to character limits
             if (len(post) <= 9900):


### PR DESCRIPTION
~~I have implemented this feature to be as similar to the other existing selectors. But for sites like Bloomberg that have different HTML structures for its different sections/articles, I find that it is preferably and more consistent to use the metadata to get the authors' names for these sites.~~

~~For example to extract name from this meta tag:
`<meta name="author" content="John">`
You can use the below text for the authors_selector in sites.json.
`"meta[name='author']"`~~

~~Again, for sites like Bloomberg that uses different meta tag for different sections/articles like:
`<meta name="author" content="John">` or `<meta name="parsely-author" content="John">`
You can use the below text to state multiple tag names.
`"meta[name='author'|'parsely-author']"`~~

~~Authors' names are currently left blank for articles that do not list any.~~

Edit: authors' names are added to articles using response from Mercury web parser.